### PR TITLE
[DS-5600] Add UTM support to Stripe sessions and refactor session payload

### DIFF
--- a/server.js
+++ b/server.js
@@ -44,53 +44,33 @@ app.use(cors(corsOptions));
 
 const getCurrentDate = () => {
   const currentDate = new Date();
-  const day = currentDate.getDate();
-  const month = currentDate.getMonth() + 1;
-  const year = currentDate.getFullYear();
-  return `${day}/${month}/${year}`;
+  return `${currentDate.getDate()}/${currentDate.getMonth() + 1}/${currentDate.getFullYear()}`;
 };
 
+const getCurrentDateTime = () => new Date().toISOString();
 
-const getCurrentDateTime = () => {
-  const currentDateTime = new Date().toISOString();
-  return currentDateTime;
-};
 app.post(`${folderNode}create-checkout-session`, async (req, res) => {
   try {
+    const { customerEmail, promotionCode, ...utmParams } = req.body;
+
     let createObj = {
       ui_mode: 'embedded',
-      line_items: [
-        {
-          price: ticketPriceId,
-          quantity: 1,
-        },
-      ],
-      custom_fields: [
-        {
-          key: 'taxid',
-          label: {
-            type: 'custom',
-            custom: 'CUIT/TAXID/NIF/CIF/RFC/CC/RUC/DUI/RUT',
-          },
-          type: 'text',
-          optional: false
-        },
-      ],
+      line_items: [{ price: ticketPriceId, quantity: 1 }],
+      custom_fields: [{
+        key: 'taxid',
+        label: { type: 'custom', custom: 'CUIT/TAXID/NIF/CIF/RFC/CC/RUC/DUI/RUT' },
+        type: 'text',
+        optional: false
+      }],
       mode: 'payment',
       payment_method_types: ['card'],
-      return_url: `${ORIGIN_DOMAIN_EMMS}${RETURN_URL}?session_id={CHECKOUT_SESSION_ID}`,
+      return_url: `${ORIGIN_DOMAIN_EMMS}${RETURN_URL}?session_id={CHECKOUT_SESSION_ID}&${new URLSearchParams(utmParams)}`,
       automatic_tax: { enabled: true },
     };
 
-    if (req.body.customerEmail) {
-      createObj.customer_email = req.body.customerEmail;
-    }
-
-    if (req.body.promotionCode) {
-      const promotionCode = req.body.promotionCode;
-      createObj.discounts = [
-        { promotion_code: promotionCode }
-      ];
+    if (customerEmail) createObj.customer_email = customerEmail;
+    if (promotionCode) {
+      createObj.discounts = [{ promotion_code: promotionCode }];
     } else {
       createObj.allow_promotion_codes = true;
     }
@@ -109,15 +89,22 @@ app.get(`${folderNode}session-status`, async (req, res) => {
       expand: ['customer', 'total_details.breakdown'],
     });
 
+    const utmParams = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'origin'];
+
+    const utmData = utmParams.reduce((acc, param) => {
+      acc[param] = req.query[param] || null;
+      return acc;
+    }, {});
+
     const filteredSession = {
       price: (session.amount_subtotal / 100).toFixed(2),
       discount: (session.total_details.amount_discount / 100).toFixed(2),
       final_price: ((session.amount_subtotal - session.total_details.amount_discount) / 100).toFixed(2),
       currency: session.currency,
-      customer_name: session.customer_details.name,
-      customer_email: session.customer_details.email,
-      customer_country: session.customer_details.address.country,
-      tax_id: session.custom_fields.find(field => field.key === 'taxid')?.text?.value,
+      customer_name: session.customer_details?.name,
+      customer_email: session.customer_details?.email,
+      customer_country: session.customer_details?.address?.country,
+      tax_id: session.custom_fields?.find(field => field.key === 'taxid')?.text?.value,
       payment_status: session.payment_status,
       session_id: session.id,
       coupon_id: session.total_details.breakdown.discounts[0]?.discount?.coupon?.id ?? null,
@@ -127,19 +114,23 @@ app.get(`${folderNode}session-status`, async (req, res) => {
       ticket_name: ticketName,
       ticket_price_id: ticketPriceId,
       date: getCurrentDate(),
-      datetime: getCurrentDateTime()
+      datetime: getCurrentDateTime(),
+      ...utmData
     };
 
     const response = await axios.post(createCustomerUrl, filteredSession);
+
     res.send({
       status: session.status,
       customer_details: filteredSession,
       response: response.data
     });
+
   } catch (error) {
     console.error('Error retrieving session:', error);
     res.status(500).send({ error: 'Error retrieving session' });
   }
 });
+
 
 app.listen(PORT, () => console.log('Running on port ' + PORT));


### PR DESCRIPTION
## 📌 Contexto

Este PR resuelve el ticket [DS-5600](https://makingsense.atlassian.net/browse/DS-5600), con el objetivo de mejorar el tracking de campañas de marketing agregando soporte para parámetros UTM en el flujo de pago con Stripe y enriquecer la información enviada al backend.

---

## ✅ Qué incluye

- Se capturan los parámetros UTM (`utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`, `origin`) desde la request.
- Se agregan estos parámetros al `return_url` de Stripe.
- Se envían los datos UTM al endpoint `createCustomerUrl` como parte del payload.
- Se refactorizan las funciones de fecha y hora (`getCurrentDate`, `getCurrentDateTime`) para mayor claridad.
- Se utiliza optional chaining para evitar errores cuando faltan datos de la sesión (por ejemplo, `customer_details` o `custom_fields`).
- Se mejora la estructura del objeto `createObj` enviado a Stripe para mayor legibilidad.

---

## 🛠 Mejoras menores

- Limpieza y simplificación de funciones utilitarias.
- Código más legible y organizado.


[DS-5600]: https://makingsense.atlassian.net/browse/DS-5600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ